### PR TITLE
Fix build on case-sensitive filesystem

### DIFF
--- a/FLACiOS.xcodeproj/project.pbxproj
+++ b/FLACiOS.xcodeproj/project.pbxproj
@@ -913,7 +913,7 @@
 				HEADERMAP_INCLUDES_FLAT_ENTRIES_FOR_TARGET_BEING_BUILT = NO;
 				HEADER_SEARCH_PATHS = (
 					/opt/local/include,
-					"\"${SRCROOT}/libFlac/include\"",
+					"\"${SRCROOT}/libFLAC/include\"",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",
@@ -939,7 +939,7 @@
 				HEADERMAP_INCLUDES_FLAT_ENTRIES_FOR_TARGET_BEING_BUILT = NO;
 				HEADER_SEARCH_PATHS = (
 					/opt/local/include,
-					"\"${SRCROOT}/libFlac/include\"",
+					"\"${SRCROOT}/libFLAC/include\"",
 				);
 				OTHER_CPLUSPLUSFLAGS = (
 					"$(OTHER_CFLAGS)",


### PR DESCRIPTION
It shows various errors without this changes

    /path/to/FLACiOS/libFLAC/include/private/float.h:39:10:
    fatal error: 'FLAC/ordinals.h' file not found
    #include "FLAC/ordinals.h

    /path/to/FLACiOS/libFLAC/src/flac/vorbiscomment.h:22:10:
    fatal error: 'FLAC/metadata.h' file not found
    #include "FLAC/metadata.h"

Here is my build environment on my system, including root partition
information.

    $ uname -a
    Darwin Gasols-MacBook-Pro.local 18.7.0 Darwin Kernel Version 18.7.0: Thu
    Jun 20 18:42:21 PDT 2019; root:xnu-4903.270.47~4/RELEASE_X86_64 x86_64
    $ xcodebuild -version
    Xcode 10.3
    Build version 10G8
    $ clang --version
    Apple LLVM version 10.0.1 (clang-1001.0.46.4)
    Target: x86_64-apple-darwin18.7.0
    Thread model: posix
    InstalledDir:
    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
    $ diskutil apfs list

    || APFS Container (1 found)
    || |
    || +-- Container disk1 00044596-4C7D-419F-903E-000000000000
    ||     ====================================================
    ||     APFS Container Reference:     disk1
    ||     Size (Capacity Ceiling):      250685575168 B (250.7 GB)
    ||     Capacity In Use By Volumes:   221651935232 B (221.7 GB) (88.4% used)
    ||     Capacity Not Allocated:       29033639936 B (29.0 GB) (11.6% free)
    ||     |
    ||     +-< Physical Store disk0s2 AD1944DF-18FC-4ABB-A304-000000000000
    ||     |   -----------------------------------------------------------
    ||     |   APFS Physical Store Disk:   disk0s2
    ||     |   Size:                       250685575168 B (250.7 GB)
    ||     |
    ||     +-> Volume disk1s1 695AED95-17C5-4E73-8084-000000000000
    ||     |   ---------------------------------------------------
    ||     |   APFS Volume Disk (Role):   disk1s1 (No specific role)
    ||     |   Name:                      Macintosh HD (Case-sensitive)
    ||     |   Mount Point:               /
    ||     |   Capacity Consumed:         217185615872 B (217.2 GB)
    ||     |   FileVault:                 Yes (Unlocked)